### PR TITLE
Remove volumes on docker-compose down

### DIFF
--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -150,7 +150,7 @@ def docker_services(docker_compose_file, docker_allow_fallback):
     yield Services(compose_file=docker_compose_file)
 
     # Clean up.
-    execute('docker-compose -f "%s" down' % (docker_compose_file,))
+    execute('docker-compose -f "%s" down -v' % (docker_compose_file,))
 
 
 __all__ = (

--- a/tests/test_docker_services.py
+++ b/tests/test_docker_services.py
@@ -57,7 +57,7 @@ def test_docker_services():
             shell=True, stderr=subprocess.STDOUT,
         ),
         mock.call(
-            'docker-compose -f "docker-compose.yml" down',
+            'docker-compose -f "docker-compose.yml" down -v',
             shell=True, stderr=subprocess.STDOUT,
         ),
     ]
@@ -106,7 +106,7 @@ def test_docker_services_unused_port():
             shell=True, stderr=subprocess.STDOUT,
         ),
         mock.call(
-            'docker-compose -f "docker-compose.yml" down',
+            'docker-compose -f "docker-compose.yml" down -v',
             shell=True, stderr=subprocess.STDOUT,
         ),
     ]
@@ -213,7 +213,7 @@ def test_get_port_docker_allow_fallback_docker_online():
             shell=True, stderr=subprocess.STDOUT,
         ),
         mock.call(
-            'docker-compose -f "docker-compose.yml" down',
+            'docker-compose -f "docker-compose.yml" down -v',
             shell=True, stderr=subprocess.STDOUT,
         ),
     ]


### PR DESCRIPTION
Adding the `-v` option to prevent `docker-compose down` to leak dangling volumes.

Without this patch you have to manually run `docker volume rm $(docker volume ls -qf dangling=true)` to free disk space.