### PR TITLE
Generate unique project names for docker-compose

### DIFF
--- a/tests/test_docker_compose_project_name.py
+++ b/tests/test_docker_compose_project_name.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+
+def test_docker_compose_project(docker_compose_project_name):
+    assert docker_compose_project_name == "pytest{}".format(os.getpid())

--- a/tests/test_dockercomposeexecutor.py
+++ b/tests/test_dockercomposeexecutor.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import mock
+import subprocess
+
+from pytest_docker import DockerComposeExecutor
+
+
+def test_execute():
+    docker_compose = DockerComposeExecutor("docker-compose.yml", "pytest123")
+    with mock.patch('subprocess.check_output') as check_output:
+        docker_compose.execute("up")
+        assert check_output.call_args_list == [
+            mock.call(
+                'docker-compose -f "docker-compose.yml" -p "pytest123" up',
+                shell=True, stderr=subprocess.STDOUT,
+            ),
+        ]


### PR DESCRIPTION
`docker-compose` uses a "project name" as a namespace for containers and
container names.  From the documentation:

> This value is prepended along with the service name to the container
> on start up. For example, if your project name is myapp and it
> includes two services db and web then compose starts containers named
> myapp_db_1 and myapp_web_1 respectively.

By default, it uses the name of the directory containing the
`docker-compose.yml` file.  So you put your `docker-compose.yml` in the
`tests/` directory, as is the default with `pytest-docker`, the project
name will be `tests`.

This starts being a problem when running multiple test suites using
`pytest-docker` in parallel, for instance on a build server:
`docker-compose` gets confused by the different projects with the same
name.

This fixes the problem by generating a new name for each run based on
the patern `pytest<process-id>`. This should ensure that the name is
unique on a given machine.

The project name is also a pytest fixture so it can be redefined by the
users the same way the compose file can.