### PR TITLE
Allow fixture to return multiple compose files

### DIFF
--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -102,11 +102,10 @@ class Services(object):
         )
 
 
-def str_to_list(x):
-    if isinstance(x, str):
-        return [x]
-    else:
-        return x
+def str_to_list(arg):
+    if isinstance(arg, (list, tuple)):
+        return arg
+    return [arg]
 
 
 @attr.s(frozen=True)

--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -102,16 +102,24 @@ class Services(object):
         )
 
 
+def str_to_list(x):
+    if isinstance(x, str):
+        return [x]
+    else:
+        return x
+
+
 @attr.s(frozen=True)
 class DockerComposeExecutor(object):
-    _compose_file = attr.ib()
+    _compose_files = attr.ib(convert=str_to_list)
     _compose_project_name = attr.ib()
 
-    def execute(self, command):
-        return execute(
-            'docker-compose -f "%s" -p "%s" %s' % (
-                self._compose_file, self._compose_project_name, command)
-        )
+    def execute(self, subcommand):
+        command = "docker-compose"
+        for compose_file in self._compose_files:
+            command += ' -f "{}"'.format(compose_file)
+        command += ' -p "{}" {}'.format(self._compose_project_name, subcommand)
+        return execute(command)
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_docker_services.py
+++ b/tests/test_docker_services.py
@@ -170,7 +170,7 @@ def test_wait_until_responsive_timeout():
 
     with mock.patch('time.sleep') as sleep:
         docker_compose = DockerComposeExecutor(
-            compose_file='docker-compose.yml',
+            compose_files='docker-compose.yml',
             compose_project_name="pytest123")
         services = Services(docker_compose)
         with pytest.raises(Exception) as exc:

--- a/tests/test_dockercomposeexecutor.py
+++ b/tests/test_dockercomposeexecutor.py
@@ -2,6 +2,8 @@
 import mock
 import subprocess
 
+import py
+
 from pytest_docker import DockerComposeExecutor
 
 
@@ -12,6 +14,20 @@ def test_execute():
         assert check_output.call_args_list == [
             mock.call(
                 'docker-compose -f "docker-compose.yml" -p "pytest123" up',
+                shell=True, stderr=subprocess.STDOUT,
+            ),
+        ]
+
+
+def test_pypath_compose_files():
+    compose_file = py.path.local('/tmp/docker-compose.yml')
+    docker_compose = DockerComposeExecutor(compose_file, "pytest123")
+    with mock.patch('subprocess.check_output') as check_output:
+        docker_compose.execute("up")
+        assert check_output.call_args_list == [
+            mock.call(
+                'docker-compose -f "/tmp/docker-compose.yml"'
+                ' -p "pytest123" up',
                 shell=True, stderr=subprocess.STDOUT,
             ),
         ]

--- a/tests/test_dockercomposeexecutor.py
+++ b/tests/test_dockercomposeexecutor.py
@@ -15,3 +15,17 @@ def test_execute():
                 shell=True, stderr=subprocess.STDOUT,
             ),
         ]
+
+
+def test_multiple_compose_files():
+    docker_compose = DockerComposeExecutor(
+        ["docker-compose.yml", "other-compose.yml"], "pytest123")
+    with mock.patch('subprocess.check_output') as check_output:
+        docker_compose.execute("up")
+        assert check_output.call_args_list == [
+            mock.call(
+                'docker-compose -f "docker-compose.yml" -f "other-compose.yml"'
+                ' -p "pytest123" up',
+                shell=True, stderr=subprocess.STDOUT,
+            ),
+        ]


### PR DESCRIPTION
As described in https://docs.docker.com/compose/extends/, docker compose
can be passed multiple compose files that are then merged.  This change
allows the `docker_compose_file` fixture to make use of this by
returning e.g. a list or a tuple.