### PR TITLE
tests: Fix for flake8 3.6.0

### DIFF
--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -39,7 +39,7 @@ def docker_ip():
     if not docker_host:
         return '127.0.0.1'
 
-    match = re.match('^tcp://(.+?):\d+$', docker_host)
+    match = re.match(r'^tcp://(.+?):\d+$', docker_host)
     if not match:
         raise ValueError(
             'Invalid value for DOCKER_HOST: "%s".' % (docker_host,)


### PR DESCRIPTION
With the new version of flake8 a piece of the code was raising
an error. With the fix the string produces is the same, but it's
less ambivalent, and flake8 likes it.