### PR TITLE
tests: make sure the containers and volumes die

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,3 @@
 # -*- coding: utf-8 -*-
+
+pytest_plugins = ["pytester"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from os import path
+import shutil
+import subprocess
+
 import requests
 from requests.exceptions import ConnectionError
 
@@ -33,3 +37,67 @@ def test_main_fixtures_work(docker_ip, docker_services):
     response = requests.get(url)
     # this is set up in the test image
     assert response.status_code == 204
+
+
+def test_containers_and_volumes_get_cleaned_up(testdir, tmpdir, docker_compose_file):
+    _copy_compose_files_to_testdir(testdir, docker_compose_file)
+
+    project_name_file_path = path.join(str(tmpdir), 'project_name.txt')
+    testdir.makepyfile("""
+    import subprocess
+
+    def _check_volume_exists(project_name):
+        check_proc = subprocess.Popen(
+            "docker volume ls".split(),
+            stdout=subprocess.PIPE,
+        )
+        assert project_name.encode() in check_proc.stdout.read()
+
+    def _check_container_exists(project_name):
+        check_proc = subprocess.Popen(
+            "docker ps".split(),
+            stdout=subprocess.PIPE,
+        )
+        assert project_name.encode() in check_proc.stdout.read()
+
+    def test_whatever(docker_services, docker_compose_project_name):
+        _check_volume_exists(docker_compose_project_name)
+        _check_container_exists(docker_compose_project_name)
+        with open('{}', 'w') as project_name_file:
+            project_name_file.write(docker_compose_project_name)
+    """.format(str(project_name_file_path)))
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
+
+    with open(str(project_name_file_path), 'rb') as project_name_file:
+        compose_project_name = project_name_file.read().decode()
+    _check_volume_is_gone(compose_project_name)
+    _check_container_is_gone(compose_project_name)
+
+
+def _copy_compose_files_to_testdir(testdir, compose_file_path):
+    directory_for_compose_files = testdir.mkdir('tests')
+    shutil.copy(compose_file_path, str(directory_for_compose_files))
+
+    container_build_files_dir = path.realpath(path.join(compose_file_path, '../containers'))
+    shutil.copytree(
+        container_build_files_dir,
+        str(directory_for_compose_files) + '/containers',
+    )
+
+
+def _check_volume_is_gone(project_name):
+    check_proc = subprocess.Popen(
+        "docker volume ls".split(),
+        stdout=subprocess.PIPE,
+    )
+    assert project_name.encode() not in check_proc.stdout.read()
+
+
+def _check_container_is_gone(project_name):
+    check_proc = subprocess.Popen(
+        "docker ps".split(),
+        stdout=subprocess.PIPE,
+    )
+    assert project_name.encode() not in check_proc.stdout.read()


### PR DESCRIPTION
This will make it less stressful to do major refactoring of the
core of the library.