### PR TITLE
Moving build, testing, and cleanup into a try/finally block.

### DIFF
--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -148,14 +148,16 @@ def docker_services(
         docker_compose_file, docker_compose_project_name
     )
 
-    # Spawn containers.
-    docker_compose.execute('up --build -d')
 
-    # Let test(s) run.
-    yield Services(docker_compose)
+    try:
+        # Spawn containers.
+        docker_compose.execute('up --build -d')
 
-    # Clean up.
-    docker_compose.execute('down -v')
+        # Let test(s) run.
+        yield Services(docker_compose)
+    finally:
+        # Clean up.
+        docker_compose.execute('down -v')
 
 
 __all__ = (


### PR DESCRIPTION
Trying to kill pytest with SIGINT causes docker, or it's network bridges, to stay alive. I discovered this when one of the surviving network bridges killed my internet connection entirely. At other times, my computer's performance will drop from leftover docker containers running. Life is hard for the impatient!

While this will not keep someone mashing ctrl+c safe, I've found this small change reduces the possibility of leftover waste without a noticeable performance cost. 